### PR TITLE
Refactor quiz into state and view modules

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,4 +1,6 @@
 import { Quiz } from './components/Quiz'
+import { QuizState } from './components/QuizState'
+import { QuizView } from './components/QuizView'
 import { JapaneseTeacher } from './components/JapaneseTeacher'
 import { ProgressTracker } from './components/ProgressTracker'
 import { MobileDetection } from './utils/mobileDetection'
@@ -74,7 +76,9 @@ class JapaneseQuizApp {
    */
   private initializeComponents(): void {
     // Initialize Quiz component
-    this.quiz = new Quiz()
+    const quizState = new QuizState()
+    const quizView = new QuizView()
+    this.quiz = new Quiz(quizState, quizView)
 
     // Initialize Japanese Teacher component
     this.japaneseTeacher = new JapaneseTeacher()

--- a/resources/js/components/Quiz.ts
+++ b/resources/js/components/Quiz.ts
@@ -1,169 +1,71 @@
-import { QuizAPI } from '../services/QuizAPI'
+import { QuizState } from './QuizState'
+import { QuizView } from './QuizView'
 import { StorageService } from '../services/StorageService'
-import { AnimationUtils } from '../utils/animations'
 import { MobileDetection } from '../utils/mobileDetection'
 import type {
   QuizType,
-  Question,
-  QuizStartResponse,
   AnswerResponse,
   QuestionResponse,
 } from '../types/index'
 
 /**
- * Quiz Component - Handles the main quiz functionality
+ * Orchestrates quiz state and view modules
  */
 export class Quiz {
-  private quizAPI: QuizAPI
+  private state: QuizState
+  private view: QuizView
   private storageService: StorageService
 
-  // Quiz state
-  private sessionId: string | null = null
-  private currentQuestion: Question | null = null
-  private quizType: QuizType | null = null
-  private score: number = 0
-  private questionNumber: number = 0
-  private totalQuestions: number = 20
-  private hearts: number = 3
-  private maxHearts: number = 3
-  private isGameOver: boolean = false
-  private isAnswered: boolean = false
-
-  // DOM elements
-  private heroSection: HTMLElement | null = null
-  private quizInterface: HTMLElement | null = null
-  private quizResults: HTMLElement | null = null
-  private aboutSection: HTMLElement | null = null
-  private progressSection: HTMLElement | null = null
-
-  private quizTitle: HTMLElement | null = null
-  private questionCounter: HTMLElement | null = null
-  private scoreDisplay: HTMLElement | null = null
-  private heartsDisplay: HTMLElement | null = null
-  private progressBar: HTMLElement | null = null
-  private characterDisplay: HTMLElement | null = null
-  private answerOptions: HTMLElement | null = null
-  private feedbackDisplay: HTMLElement | null = null
-  private feedbackMessage: HTMLElement | null = null
-  private correctAnswer: HTMLElement | null = null
-  private nextButton: HTMLElement | null = null
-
-  private finalScore: HTMLElement | null = null
-  private finalPercentage: HTMLElement | null = null
-
-  private gameOverModal: HTMLElement | null = null
-  private gameOverScore: HTMLElement | null = null
-  private gameOverPercentage: HTMLElement | null = null
-
-  private startHiraganaBtn: HTMLElement | null = null
-  private startKatakanaBtn: HTMLElement | null = null
-  private restartBtn: HTMLElement | null = null
-  private switchModeBtn: HTMLElement | null = null
-  private gameOverRestartBtn: HTMLElement | null = null
-  private gameOverHomeBtn: HTMLElement | null = null
-
-  constructor() {
-    this.quizAPI = new QuizAPI()
+  constructor(state?: QuizState, view?: QuizView) {
+    this.state = state || new QuizState()
+    this.view = view || new QuizView()
     this.storageService = new StorageService()
 
-    this.initializeElements()
     this.bindEvents()
-  }
-
-  /**
-   * Initialize DOM elements
-   */
-  private initializeElements(): void {
-    // Sections
-    this.heroSection = document.querySelector('.bg-gradient-to-br')
-    this.quizInterface = document.getElementById('quiz-interface')
-    this.quizResults = document.getElementById('quiz-results')
-    this.aboutSection = document.getElementById('about')
-    this.progressSection = document.getElementById('progress')
-
-    // Quiz elements
-    this.quizTitle = document.getElementById('quiz-title')
-    this.questionCounter = document.getElementById('question-counter')
-    this.scoreDisplay = document.getElementById('score-display')
-    this.heartsDisplay = document.getElementById('hearts-display')
-    this.progressBar = document.getElementById('progress-bar')
-    this.characterDisplay = document.getElementById('character-display')
-    this.answerOptions = document.getElementById('answer-options')
-    this.feedbackDisplay = document.getElementById('feedback-display')
-    this.feedbackMessage = document.getElementById('feedback-message')
-    this.correctAnswer = document.getElementById('correct-answer')
-    this.nextButton = document.getElementById('next-question')
-
-    // Results elements
-    this.finalScore = document.getElementById('final-score')
-    this.finalPercentage = document.getElementById('final-percentage')
-
-    // Game Over Modal elements
-    this.gameOverModal = document.getElementById('game-over-modal')
-    this.gameOverScore = document.getElementById('game-over-score')
-    this.gameOverPercentage = document.getElementById('game-over-percentage')
-
-    // Buttons
-    this.startHiraganaBtn = document.getElementById('start-hiragana-quiz')
-    this.startKatakanaBtn = document.getElementById('start-katakana-quiz')
-    this.restartBtn = document.getElementById('restart-quiz')
-    this.switchModeBtn = document.getElementById('switch-mode')
-    this.gameOverRestartBtn = document.getElementById('game-over-restart')
-    this.gameOverHomeBtn = document.getElementById('game-over-home')
-  }
-
-  /**
-   * Bind event handlers
-   */
-  private bindEvents(): void {
-    // Quiz start buttons
-    this.startHiraganaBtn?.addEventListener('click', (e) => {
-      AnimationUtils.animateButtonPress(e.target as HTMLElement)
-      this.startQuiz('hiragana')
-    })
-
-    this.startKatakanaBtn?.addEventListener('click', (e) => {
-      AnimationUtils.animateButtonPress(e.target as HTMLElement)
-      this.startQuiz('katakana')
-    })
-
-    // Quiz control buttons
-    this.nextButton?.addEventListener('click', (e) => {
-      AnimationUtils.animateButtonPress(e.target as HTMLElement)
-      this.nextQuestion()
-    })
-
-    this.restartBtn?.addEventListener('click', (e) => {
-      AnimationUtils.animateButtonPress(e.target as HTMLElement)
-      this.restartQuiz()
-    })
-
-    this.switchModeBtn?.addEventListener('click', (e) => {
-      AnimationUtils.animateButtonPress(e.target as HTMLElement)
-      this.switchMode()
-    })
-
-    // Game Over Modal events
-    this.gameOverRestartBtn?.addEventListener('click', (e) => {
-      AnimationUtils.animateButtonPress(e.target as HTMLElement)
-      this.restartFromGameOver()
-    })
-
-    this.gameOverHomeBtn?.addEventListener('click', (e) => {
-      AnimationUtils.animateButtonPress(e.target as HTMLElement)
-      this.goHome()
-    })
-
-    // Keyboard navigation
     this.initializeKeyboardNavigation()
   }
 
-  /**
-   * Initialize keyboard navigation
-   */
+  /** Bind UI events */
+  private bindEvents(): void {
+    this.view.startHiraganaBtn?.addEventListener('click', (e) => {
+      this.view.animateButtonPress(e.target as HTMLElement)
+      this.startQuiz('hiragana')
+    })
+
+    this.view.startKatakanaBtn?.addEventListener('click', (e) => {
+      this.view.animateButtonPress(e.target as HTMLElement)
+      this.startQuiz('katakana')
+    })
+
+    this.view.nextButton?.addEventListener('click', (e) => {
+      this.view.animateButtonPress(e.target as HTMLElement)
+      this.nextQuestion()
+    })
+
+    this.view.restartBtn?.addEventListener('click', (e) => {
+      this.view.animateButtonPress(e.target as HTMLElement)
+      this.restartQuiz()
+    })
+
+    this.view.switchModeBtn?.addEventListener('click', (e) => {
+      this.view.animateButtonPress(e.target as HTMLElement)
+      this.switchMode()
+    })
+
+    this.view.gameOverRestartBtn?.addEventListener('click', (e) => {
+      this.view.animateButtonPress(e.target as HTMLElement)
+      this.restartFromGameOver()
+    })
+
+    this.view.gameOverHomeBtn?.addEventListener('click', (e) => {
+      this.view.animateButtonPress(e.target as HTMLElement)
+      this.goHome()
+    })
+  }
+
+  /** Keyboard navigation */
   private initializeKeyboardNavigation(): void {
     document.addEventListener('keydown', (e) => {
-      // Allow 1-4 keys to select answers
       if (['1', '2', '3', '4'].includes(e.key)) {
         const answerButtons = document.querySelectorAll(
           '.answer-option'
@@ -174,9 +76,8 @@ export class Quiz {
         }
       }
 
-      // Allow Enter or Space to proceed to next question
       if ((e.key === 'Enter' || e.key === ' ') && !(e.target as HTMLElement).matches('button')) {
-        const nextButton = document.getElementById('next-question')
+        const nextButton = this.view.nextButton
         if (nextButton && !nextButton.classList.contains('hidden')) {
           e.preventDefault()
           nextButton.click()
@@ -185,252 +86,97 @@ export class Quiz {
     })
   }
 
-  /**
-   * Start a new quiz
-   */
+  /** Start a new quiz */
   public async startQuiz(type: QuizType): Promise<void> {
     try {
-      const data: QuizStartResponse = await this.quizAPI.startQuiz(type)
+      await this.state.startQuiz(type)
+      this.view.showQuizInterface(type)
 
-      this.sessionId = data.sessionId
-      this.quizType = type
-      this.totalQuestions = data.totalQuestions
-      this.currentQuestion = data.currentQuestion
-      this.score = 0
-      this.hearts = data.hearts || 3
-      this.maxHearts = data.maxHearts || 3
-      this.isGameOver = data.isGameOver || false
-      this.questionNumber = 1
-      this.isAnswered = false
-
-      this.showQuizInterface()
-      this.displayQuestion()
+      const question = this.state.getCurrentQuestion()
+      if (question) {
+        this.view.displayQuestion(
+          this.state.getQuestionNumber(),
+          this.state.getTotalQuestions(),
+          this.state.getScore(),
+          question,
+          this.state.getHearts(),
+          this.state.getMaxHearts(),
+          (answer, btn) => this.selectAnswer(answer, btn)
+        )
+      }
     } catch (error) {
       console.error('Error starting quiz:', error)
       alert('Failed to start quiz. Please try again.')
     }
   }
 
-  /**
-   * Show the quiz interface
-   */
-  private showQuizInterface(): void {
-    this.heroSection?.classList.add('hidden')
-    this.aboutSection?.classList.add('hidden')
-    this.progressSection?.classList.add('hidden')
-    this.quizResults?.classList.add('hidden')
-    this.quizInterface?.classList.remove('hidden')
-
-    if (this.quizTitle) {
-      this.quizTitle.textContent = this.quizType === 'hiragana' ? 'Hiragana Quiz' : 'Katakana Quiz'
-    }
-  }
-
-  /**
-   * Display the current question
-   */
-  private displayQuestion(): void {
-    if (!this.currentQuestion) return
-
-    // Update UI elements
-    if (this.questionCounter) {
-      this.questionCounter.textContent = `Question ${this.questionNumber} of ${this.totalQuestions}`
-    }
-    if (this.scoreDisplay) {
-      this.scoreDisplay.textContent = `Score: ${this.score}`
-    }
-
-    this.updateHeartsDisplay()
-
-    // Animate progress bar
-    const progressPercentage = (this.questionNumber / this.totalQuestions) * 100
-    if (this.progressBar) {
-      AnimationUtils.animateProgressBar(this.progressBar as HTMLElement, progressPercentage)
-    }
-
-    // Display character
-    if (this.characterDisplay) {
-      this.characterDisplay.textContent = this.currentQuestion.character
-    }
-
-    // Create answer options
-    this.createAnswerOptions()
-
-    // Hide feedback and next button
-    this.feedbackDisplay?.classList.add('hidden')
-    this.nextButton?.classList.add('hidden')
-    this.isAnswered = false
-  }
-
-  /**
-   * Create answer option buttons
-   */
-  private createAnswerOptions(): void {
-    if (!this.answerOptions || !this.currentQuestion) return
-
-    this.answerOptions.innerHTML = ''
-
-    this.currentQuestion.options.forEach((option) => {
-      const button = document.createElement('button')
-      button.className =
-        'answer-option bg-gray-100 hover:bg-primary-50 active:bg-primary-100 border-2 border-transparent hover:border-primary-300 focus:border-primary-500 rounded-lg p-4 sm:p-4 text-base sm:text-lg font-medium transition-colors-smooth transform hover:scale-[1.02] active:scale-[0.98] min-h-[44px] quiz-button'
-      button.textContent = option
-      button.addEventListener('click', () => this.selectAnswer(option, button))
-      this.answerOptions?.appendChild(button)
-    })
-  }
-
-  /**
-   * Update hearts display
-   */
-  private updateHeartsDisplay(): void {
-    if (!this.heartsDisplay) return
-
-    const previousHearts = this.heartsDisplay.querySelectorAll('.heart.text-red-500').length
-    this.heartsDisplay.innerHTML = ''
-
-    for (let i = 0; i < this.maxHearts; i++) {
-      const heart = document.createElement('span')
-      heart.className = 'heart text-xl transition-all-smooth'
-
-      if (i < this.hearts) {
-        heart.textContent = '❤️'
-        heart.classList.add('text-red-500')
-      } else {
-        heart.textContent = '🤍'
-        heart.classList.add('text-gray-300')
-
-        // Animate heart loss if this heart was just lost
-        if (i === this.hearts && previousHearts > this.hearts) {
-          setTimeout(() => AnimationUtils.animateHeartLoss(heart), 100)
-        }
-      }
-
-      this.heartsDisplay.appendChild(heart)
-    }
-  }
-
-  /**
-   * Handle answer selection
-   */
+  /** Handle answer selection */
   private async selectAnswer(selectedAnswer: string, buttonElement: HTMLElement): Promise<void> {
-    if (this.isAnswered || !this.sessionId) return
-    this.isAnswered = true
+    if (this.state.getIsAnswered() || !this.state.getSessionId()) return
+    this.state.setAnswered(true)
 
-    // Animate button press
-    AnimationUtils.animateButtonPress(buttonElement)
+    this.view.animateButtonPress(buttonElement)
 
-    // Add haptic feedback for mobile
     if (MobileDetection.isMobile()) {
       MobileDetection.vibrate(50)
     }
 
     try {
-      const data: AnswerResponse = await this.quizAPI.submitAnswer(this.sessionId, selectedAnswer)
+      const data: AnswerResponse = await this.state.submitAnswer(selectedAnswer)
 
-      this.score = data.score
-      this.questionNumber = data.questionNumber
-      this.hearts = data.hearts
-      this.isGameOver = data.isGameOver
+      this.view.showFeedback(data.isCorrect, data.correctAnswer, buttonElement)
+      this.view.updateHeartsDisplay(this.state.getHearts(), this.state.getMaxHearts())
 
-      // Show feedback
-      this.showFeedback(data.isCorrect, data.correctAnswer, buttonElement)
-
-      // Check for game over due to no hearts
       if (data.isGameOver && data.gameOverReason === 'no_hearts') {
         setTimeout(() => {
-          this.showGameOverModal()
+          this.view.showGameOverModal(this.state.getScore(), this.state.getQuestionNumber())
         }, 2000)
       } else if (data.completed) {
-        this.showResults(data)
+        this.handleQuizCompletion(data.finalScore || this.state.getScore(), data.heartsRemaining || this.state.getHearts())
       } else {
-        this.nextButton?.classList.remove('hidden')
+        this.view.showNextButton()
       }
     } catch (error) {
       console.error('Error submitting answer:', error)
       alert('Failed to submit answer. Please try again.')
-      this.isAnswered = false
+      this.state.setAnswered(false)
     }
   }
 
-  /**
-   * Show answer feedback
-   */
-  private showFeedback(
-    isCorrect: boolean,
-    correctAnswer: string,
-    selectedButton: HTMLElement
-  ): void {
-    // Disable all buttons
-    const allButtons = this.answerOptions?.querySelectorAll(
-      '.answer-option'
-    ) as NodeListOf<HTMLButtonElement>
-    allButtons?.forEach((btn) => {
-      btn.disabled = true
-      btn.classList.remove('hover:bg-primary-50', 'hover:border-primary-300')
-    })
-
-    // Highlight correct and incorrect answers with animations
-    allButtons?.forEach((btn) => {
-      if (btn.textContent === correctAnswer) {
-        btn.classList.add('bg-green-100', 'border-green-500', 'text-green-800')
-        AnimationUtils.animateCorrectAnswer(btn)
-      } else if (btn === selectedButton && !isCorrect) {
-        btn.classList.add('bg-red-100', 'border-red-500', 'text-red-800')
-        AnimationUtils.animateIncorrectAnswer(btn)
-      }
-    })
-
-    // Show feedback message
-    if (this.feedbackMessage) {
-      this.feedbackMessage.textContent = isCorrect ? '✅ Correct!' : '❌ Wrong!'
-      this.feedbackMessage.className = `text-lg font-semibold mb-2 ${isCorrect ? 'text-green-600' : 'text-red-600'}`
-    }
-
-    if (!isCorrect && this.correctAnswer) {
-      this.correctAnswer.textContent = `Correct answer: ${correctAnswer}`
-      this.correctAnswer.classList.remove('hidden')
-    } else if (this.correctAnswer) {
-      this.correctAnswer.classList.add('hidden')
-    }
-
-    this.feedbackDisplay?.classList.remove('hidden')
-  }
-
-  /**
-   * Move to next question
-   */
+  /** Retrieve next question */
   private async nextQuestion(): Promise<void> {
-    if (!this.sessionId) return
+    if (!this.state.getSessionId()) return
 
     try {
-      const data: QuestionResponse = await this.quizAPI.getQuestion(this.sessionId)
+      const data: QuestionResponse = await this.state.getNextQuestion()
 
       if (data.completed) {
         if (data.isGameOver && data.gameOverReason === 'no_hearts') {
-          this.showGameOverModal()
+          this.view.showGameOverModal(this.state.getScore(), this.state.getQuestionNumber())
         } else {
-          this.showResults(data)
+          this.handleQuizCompletion(data.finalScore || this.state.getScore(), data.heartsRemaining || this.state.getHearts())
         }
       } else {
-        this.currentQuestion = data.question || null
-        this.hearts = data.hearts
-        this.isGameOver = data.isGameOver
-
-        // Animate question transition
-        const questionDisplay = this.characterDisplay?.parentElement
-        const answerOptions = this.answerOptions
+        const question = this.state.getCurrentQuestion()
+        const questionDisplay = this.view.characterDisplay?.parentElement as HTMLElement
+        const answerOptions = this.view.answerOptions as HTMLElement
 
         if (questionDisplay && answerOptions) {
-          await AnimationUtils.animateQuestionTransition(
-            questionDisplay as HTMLElement,
-            answerOptions as HTMLElement
-          )
+          await this.view.animateQuestionTransition(questionDisplay, answerOptions)
         }
 
-        // Display question after animation
         setTimeout(() => {
-          this.displayQuestion()
+          if (question) {
+            this.view.displayQuestion(
+              this.state.getQuestionNumber(),
+              this.state.getTotalQuestions(),
+              this.state.getScore(),
+              question,
+              this.state.getHearts(),
+              this.state.getMaxHearts(),
+              (answer, btn) => this.selectAnswer(answer, btn)
+            )
+          }
         }, 200)
       }
     } catch (error) {
@@ -439,125 +185,76 @@ export class Quiz {
     }
   }
 
-  /**
-   * Show quiz results
-   */
-  private showResults(data: AnswerResponse | QuestionResponse): void {
-    this.quizInterface?.classList.add('hidden')
-    this.quizResults?.classList.remove('hidden')
+  /** Handle quiz completion */
+  private handleQuizCompletion(finalScore: number, heartsRemaining: number): void {
+    this.view.showResults(finalScore, this.state.getTotalQuestions(), heartsRemaining)
 
-    const finalScore = data.finalScore || this.score
-    const percentage = Math.round((finalScore / this.totalQuestions) * 100)
-    const heartsRemaining = data.heartsRemaining || this.hearts
-
-    if (this.finalScore) {
-      this.finalScore.textContent = `Score: ${finalScore}/${this.totalQuestions}`
-    }
-    if (this.finalPercentage) {
-      this.finalPercentage.textContent = `${percentage}% Correct • ${heartsRemaining} ❤️ remaining`
-    }
-
-    // Update progress tracking
-    if (this.quizType) {
-      this.storageService.updateStats(this.quizType, finalScore, this.totalQuestions)
-
-      // Dispatch custom event for progress update
+    const type = this.state.getQuizType()
+    if (type) {
+      this.storageService.updateStats(type, finalScore, this.state.getTotalQuestions())
       window.dispatchEvent(
         new CustomEvent('quizCompleted', {
-          detail: { type: this.quizType, score: finalScore, total: this.totalQuestions },
+          detail: { type, score: finalScore, total: this.state.getTotalQuestions() },
         })
       )
     }
   }
 
-  /**
-   * Show game over modal
-   */
-  private showGameOverModal(): void {
-    const percentage = Math.round((this.score / this.questionNumber) * 100)
-
-    if (this.gameOverScore) {
-      this.gameOverScore.textContent = `Score: ${this.score}/${this.questionNumber}`
-    }
-    if (this.gameOverPercentage) {
-      this.gameOverPercentage.textContent = `${percentage}% Correct`
-    }
-
-    this.gameOverModal?.classList.remove('hidden')
-  }
-
-  /**
-   * Hide game over modal
-   */
-  private hideGameOverModal(): void {
-    this.gameOverModal?.classList.add('hidden')
-  }
-
-  /**
-   * Restart quiz from game over state
-   */
-  private restartFromGameOver(): void {
-    this.hideGameOverModal()
-    this.restartQuiz()
-  }
-
-  /**
-   * Restart current quiz
-   */
+  /** Restart the current quiz */
   private restartQuiz(): void {
-    if (this.quizType) {
-      this.startQuiz(this.quizType)
+    const type = this.state.getQuizType()
+    if (type) {
+      this.startQuiz(type)
     }
   }
 
-  /**
-   * Switch to different quiz mode
-   */
+  /** Switch quiz mode */
   private switchMode(): void {
     this.showHome()
   }
 
-  /**
-   * Go back to home screen
-   */
+  /** Restart after game over */
+  private restartFromGameOver(): void {
+    this.view.hideGameOverModal()
+    this.restartQuiz()
+  }
+
+  /** Return to home screen */
   private goHome(): void {
-    this.hideGameOverModal()
+    this.view.hideGameOverModal()
     this.showHome()
   }
 
-  /**
-   * Show home screen
-   */
+  /** Show home screen */
   public showHome(): void {
-    this.quizInterface?.classList.add('hidden')
-    this.quizResults?.classList.add('hidden')
-    this.heroSection?.classList.remove('hidden')
-    this.aboutSection?.classList.remove('hidden')
-    this.progressSection?.classList.remove('hidden')
+    this.view.showHome()
   }
 
-  // Public getters for app state
+  // Getters for app.ts
   public getSessionId(): string | null {
-    return this.sessionId
+    return this.state.getSessionId()
   }
 
   public getQuizType(): QuizType | null {
-    return this.quizType
+    return this.state.getQuizType()
   }
 
   public getScore(): number {
-    return this.score
+    return this.state.getScore()
   }
 
   public getQuestionNumber(): number {
-    return this.questionNumber
+    return this.state.getQuestionNumber()
   }
 
   public getHearts(): number {
-    return this.hearts
+    return this.state.getHearts()
   }
 
   public getIsGameOver(): boolean {
-    return this.isGameOver
+    return this.state.getIsGameOver()
   }
 }
+
+export default Quiz
+

--- a/resources/js/components/QuizState.ts
+++ b/resources/js/components/QuizState.ts
@@ -1,0 +1,140 @@
+import { QuizAPI } from '../services/QuizAPI'
+import type {
+  QuizType,
+  Question,
+  QuizStartResponse,
+  AnswerResponse,
+  QuestionResponse,
+} from '../types/index'
+
+/**
+ * Manages quiz session and state data
+ */
+export class QuizState {
+  private quizAPI: QuizAPI
+  private sessionId: string | null = null
+  private quizType: QuizType | null = null
+  private currentQuestion: Question | null = null
+  private score = 0
+  private questionNumber = 0
+  private totalQuestions = 20
+  private hearts = 3
+  private maxHearts = 3
+  private isGameOver = false
+  private isAnswered = false
+
+  constructor() {
+    this.quizAPI = new QuizAPI()
+  }
+
+  /** Start a new quiz session */
+  public async startQuiz(type: QuizType): Promise<QuizStartResponse> {
+    const data = await this.quizAPI.startQuiz(type)
+
+    this.sessionId = data.sessionId
+    this.quizType = type
+    this.totalQuestions = data.totalQuestions
+    this.currentQuestion = data.currentQuestion
+    this.score = 0
+    this.hearts = data.hearts || 3
+    this.maxHearts = data.maxHearts || 3
+    this.isGameOver = data.isGameOver || false
+    this.questionNumber = 1
+    this.isAnswered = false
+
+    return data
+  }
+
+  /** Submit an answer for the current question */
+  public async submitAnswer(answer: string): Promise<AnswerResponse> {
+    if (!this.sessionId) throw new Error('No active session')
+
+    const data = await this.quizAPI.submitAnswer(this.sessionId, answer)
+
+    this.score = data.score
+    this.questionNumber = data.questionNumber
+    this.hearts = data.hearts
+    this.isGameOver = data.isGameOver
+    this.isAnswered = true
+
+    return data
+  }
+
+  /** Fetch the next question from the API */
+  public async getNextQuestion(): Promise<QuestionResponse> {
+    if (!this.sessionId) throw new Error('No active session')
+
+    const data = await this.quizAPI.getQuestion(this.sessionId)
+
+    if (!data.completed) {
+      this.currentQuestion = data.question || null
+      this.hearts = data.hearts
+      this.isGameOver = data.isGameOver
+      this.isAnswered = false
+    }
+
+    return data
+  }
+
+  /** Reset state to defaults */
+  public restart(): void {
+    this.sessionId = null
+    this.quizType = null
+    this.currentQuestion = null
+    this.score = 0
+    this.questionNumber = 0
+    this.totalQuestions = 20
+    this.hearts = 3
+    this.maxHearts = 3
+    this.isGameOver = false
+    this.isAnswered = false
+  }
+
+  // Getters
+  public getSessionId(): string | null {
+    return this.sessionId
+  }
+
+  public getQuizType(): QuizType | null {
+    return this.quizType
+  }
+
+  public getCurrentQuestion(): Question | null {
+    return this.currentQuestion
+  }
+
+  public getScore(): number {
+    return this.score
+  }
+
+  public getQuestionNumber(): number {
+    return this.questionNumber
+  }
+
+  public getTotalQuestions(): number {
+    return this.totalQuestions
+  }
+
+  public getHearts(): number {
+    return this.hearts
+  }
+
+  public getMaxHearts(): number {
+    return this.maxHearts
+  }
+
+  public getIsGameOver(): boolean {
+    return this.isGameOver
+  }
+
+  public getIsAnswered(): boolean {
+    return this.isAnswered
+  }
+
+  public setAnswered(value: boolean): void {
+    this.isAnswered = value
+  }
+}
+
+export default QuizState
+

--- a/resources/js/components/QuizView.ts
+++ b/resources/js/components/QuizView.ts
@@ -1,0 +1,275 @@
+import { AnimationUtils } from '../utils/animations'
+import type { QuizType, Question } from '../types/index'
+
+/**
+ * Handles all DOM manipulation and animations for the quiz
+ */
+export class QuizView {
+  public heroSection: HTMLElement | null = null
+  public quizInterface: HTMLElement | null = null
+  public quizResults: HTMLElement | null = null
+  public aboutSection: HTMLElement | null = null
+  public progressSection: HTMLElement | null = null
+
+  public quizTitle: HTMLElement | null = null
+  public questionCounter: HTMLElement | null = null
+  public scoreDisplay: HTMLElement | null = null
+  public heartsDisplay: HTMLElement | null = null
+  public progressBar: HTMLElement | null = null
+  public characterDisplay: HTMLElement | null = null
+  public answerOptions: HTMLElement | null = null
+  public feedbackDisplay: HTMLElement | null = null
+  public feedbackMessage: HTMLElement | null = null
+  public correctAnswer: HTMLElement | null = null
+  public nextButton: HTMLElement | null = null
+
+  public finalScore: HTMLElement | null = null
+  public finalPercentage: HTMLElement | null = null
+
+  public gameOverModal: HTMLElement | null = null
+  public gameOverScore: HTMLElement | null = null
+  public gameOverPercentage: HTMLElement | null = null
+
+  public startHiraganaBtn: HTMLElement | null = null
+  public startKatakanaBtn: HTMLElement | null = null
+  public restartBtn: HTMLElement | null = null
+  public switchModeBtn: HTMLElement | null = null
+  public gameOverRestartBtn: HTMLElement | null = null
+  public gameOverHomeBtn: HTMLElement | null = null
+
+  constructor() {
+    this.initializeElements()
+  }
+
+  /** Initialize DOM references */
+  private initializeElements(): void {
+    // Sections
+    this.heroSection = document.querySelector('.bg-gradient-to-br')
+    this.quizInterface = document.getElementById('quiz-interface')
+    this.quizResults = document.getElementById('quiz-results')
+    this.aboutSection = document.getElementById('about')
+    this.progressSection = document.getElementById('progress')
+
+    // Quiz elements
+    this.quizTitle = document.getElementById('quiz-title')
+    this.questionCounter = document.getElementById('question-counter')
+    this.scoreDisplay = document.getElementById('score-display')
+    this.heartsDisplay = document.getElementById('hearts-display')
+    this.progressBar = document.getElementById('progress-bar')
+    this.characterDisplay = document.getElementById('character-display')
+    this.answerOptions = document.getElementById('answer-options')
+    this.feedbackDisplay = document.getElementById('feedback-display')
+    this.feedbackMessage = document.getElementById('feedback-message')
+    this.correctAnswer = document.getElementById('correct-answer')
+    this.nextButton = document.getElementById('next-question')
+
+    // Results elements
+    this.finalScore = document.getElementById('final-score')
+    this.finalPercentage = document.getElementById('final-percentage')
+
+    // Game Over Modal elements
+    this.gameOverModal = document.getElementById('game-over-modal')
+    this.gameOverScore = document.getElementById('game-over-score')
+    this.gameOverPercentage = document.getElementById('game-over-percentage')
+
+    // Buttons
+    this.startHiraganaBtn = document.getElementById('start-hiragana-quiz')
+    this.startKatakanaBtn = document.getElementById('start-katakana-quiz')
+    this.restartBtn = document.getElementById('restart-quiz')
+    this.switchModeBtn = document.getElementById('switch-mode')
+    this.gameOverRestartBtn = document.getElementById('game-over-restart')
+    this.gameOverHomeBtn = document.getElementById('game-over-home')
+  }
+
+  /** Show quiz interface and hide home/progress sections */
+  public showQuizInterface(type: QuizType): void {
+    this.heroSection?.classList.add('hidden')
+    this.aboutSection?.classList.add('hidden')
+    this.progressSection?.classList.add('hidden')
+    this.quizResults?.classList.add('hidden')
+    this.quizInterface?.classList.remove('hidden')
+
+    if (this.quizTitle) {
+      this.quizTitle.textContent = type === 'hiragana' ? 'Hiragana Quiz' : 'Katakana Quiz'
+    }
+  }
+
+  /** Display current question and options */
+  public displayQuestion(
+    questionNumber: number,
+    totalQuestions: number,
+    score: number,
+    question: Question,
+    hearts: number,
+    maxHearts: number,
+    onSelect: (answer: string, btn: HTMLElement) => void
+  ): void {
+    if (this.questionCounter) {
+      this.questionCounter.textContent = `Question ${questionNumber} of ${totalQuestions}`
+    }
+    if (this.scoreDisplay) {
+      this.scoreDisplay.textContent = `Score: ${score}`
+    }
+
+    this.updateHeartsDisplay(hearts, maxHearts)
+
+    const progressPercentage = (questionNumber / totalQuestions) * 100
+    if (this.progressBar) {
+      AnimationUtils.animateProgressBar(this.progressBar as HTMLElement, progressPercentage)
+    }
+
+    if (this.characterDisplay) {
+      this.characterDisplay.textContent = question.character
+    }
+
+    this.createAnswerOptions(question.options, onSelect)
+
+    this.feedbackDisplay?.classList.add('hidden')
+    this.nextButton?.classList.add('hidden')
+  }
+
+  /** Create answer option buttons */
+  private createAnswerOptions(
+    options: string[],
+    onSelect: (answer: string, btn: HTMLElement) => void
+  ): void {
+    if (!this.answerOptions) return
+
+    this.answerOptions.innerHTML = ''
+
+    options.forEach((option) => {
+      const button = document.createElement('button')
+      button.className =
+        'answer-option bg-gray-100 hover:bg-primary-50 active:bg-primary-100 border-2 border-transparent hover:border-primary-300 focus:border-primary-500 rounded-lg p-4 sm:p-4 text-base sm:text-lg font-medium transition-colors-smooth transform hover:scale-[1.02] active:scale-[0.98] min-h-[44px] quiz-button'
+      button.textContent = option
+      button.addEventListener('click', () => onSelect(option, button))
+      this.answerOptions?.appendChild(button)
+    })
+  }
+
+  /** Update hearts display */
+  public updateHeartsDisplay(hearts: number, maxHearts: number): void {
+    if (!this.heartsDisplay) return
+
+    const previousHearts = this.heartsDisplay.querySelectorAll('.heart.text-red-500').length
+    this.heartsDisplay.innerHTML = ''
+
+    for (let i = 0; i < maxHearts; i++) {
+      const heart = document.createElement('span')
+      heart.className = 'heart text-xl transition-all-smooth'
+
+      if (i < hearts) {
+        heart.textContent = '❤️'
+        heart.classList.add('text-red-500')
+      } else {
+        heart.textContent = '🤍'
+        heart.classList.add('text-gray-300')
+
+        if (i === hearts && previousHearts > hearts) {
+          setTimeout(() => AnimationUtils.animateHeartLoss(heart), 100)
+        }
+      }
+
+      this.heartsDisplay.appendChild(heart)
+    }
+  }
+
+  /** Show answer feedback */
+  public showFeedback(
+    isCorrect: boolean,
+    correctAnswer: string,
+    selectedButton: HTMLElement
+  ): void {
+    const allButtons = this.answerOptions?.querySelectorAll(
+      '.answer-option'
+    ) as NodeListOf<HTMLButtonElement>
+    allButtons?.forEach((btn) => {
+      btn.disabled = true
+      btn.classList.remove('hover:bg-primary-50', 'hover:border-primary-300')
+      if (btn.textContent === correctAnswer) {
+        btn.classList.add('bg-green-100', 'border-green-500', 'text-green-800')
+        AnimationUtils.animateCorrectAnswer(btn)
+      } else if (btn === selectedButton && !isCorrect) {
+        btn.classList.add('bg-red-100', 'border-red-500', 'text-red-800')
+        AnimationUtils.animateIncorrectAnswer(btn)
+      }
+    })
+
+    if (this.feedbackMessage) {
+      this.feedbackMessage.textContent = isCorrect ? '✅ Correct!' : '❌ Wrong!'
+      this.feedbackMessage.className = `text-lg font-semibold mb-2 ${isCorrect ? 'text-green-600' : 'text-red-600'}`
+    }
+
+    if (!isCorrect && this.correctAnswer) {
+      this.correctAnswer.textContent = `Correct answer: ${correctAnswer}`
+      this.correctAnswer.classList.remove('hidden')
+    } else if (this.correctAnswer) {
+      this.correctAnswer.classList.add('hidden')
+    }
+
+    this.feedbackDisplay?.classList.remove('hidden')
+  }
+
+  /** Show final quiz results */
+  public showResults(finalScore: number, totalQuestions: number, heartsRemaining: number): void {
+    this.quizInterface?.classList.add('hidden')
+    this.quizResults?.classList.remove('hidden')
+
+    const percentage = Math.round((finalScore / totalQuestions) * 100)
+    if (this.finalScore) {
+      this.finalScore.textContent = `Score: ${finalScore}/${totalQuestions}`
+    }
+    if (this.finalPercentage) {
+      this.finalPercentage.textContent = `${percentage}% Correct • ${heartsRemaining} ❤️ remaining`
+    }
+  }
+
+  /** Show game over modal */
+  public showGameOverModal(score: number, questionNumber: number): void {
+    const percentage = Math.round((score / questionNumber) * 100)
+
+    if (this.gameOverScore) {
+      this.gameOverScore.textContent = `Score: ${score}/${questionNumber}`
+    }
+    if (this.gameOverPercentage) {
+      this.gameOverPercentage.textContent = `${percentage}% Correct`
+    }
+
+    this.gameOverModal?.classList.remove('hidden')
+  }
+
+  /** Hide game over modal */
+  public hideGameOverModal(): void {
+    this.gameOverModal?.classList.add('hidden')
+  }
+
+  /** Show home screen */
+  public showHome(): void {
+    this.quizInterface?.classList.add('hidden')
+    this.quizResults?.classList.add('hidden')
+    this.heroSection?.classList.remove('hidden')
+    this.aboutSection?.classList.remove('hidden')
+    this.progressSection?.classList.remove('hidden')
+  }
+
+  /** Show next button */
+  public showNextButton(): void {
+    this.nextButton?.classList.remove('hidden')
+  }
+
+  /** Animate button press */
+  public animateButtonPress(el: HTMLElement): void {
+    AnimationUtils.animateButtonPress(el)
+  }
+
+  /** Animate question transition */
+  public async animateQuestionTransition(
+    questionDisplay: HTMLElement,
+    answerOptions: HTMLElement
+  ): Promise<void> {
+    await AnimationUtils.animateQuestionTransition(questionDisplay, answerOptions)
+  }
+}
+
+export default QuizView
+


### PR DESCRIPTION
## Summary
- Add `QuizState` for session, score, and hearts management
- Introduce `QuizView` for DOM and animation handling
- Refactor `Quiz` to orchestrate state and view and update app initialization

## Testing
- `LOG_LEVEL=info HOST=localhost APP_KEY=averylongsecretkey123 PORT=3333 NODE_ENV=test npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897720ff5a08327a236338b61f77ac4