### PR TITLE
feat: reuse OpenAI service instance

### DIFF
--- a/app/controllers/home_controller.ts
+++ b/app/controllers/home_controller.ts
@@ -105,9 +105,9 @@ export default class HomeController {
         })
       }
 
-      const openaiService = new OpenAIService()
+      const openaiService = OpenAIService.getInstance()
 
-      if (!openaiService.isConfigured()) {
+      if (!openaiService.configured) {
         return response.internalServerError({
           error: 'OpenAI service is not properly configured. Please check API key.',
         })

--- a/tests/unit/openai_service_config.spec.ts
+++ b/tests/unit/openai_service_config.spec.ts
@@ -1,0 +1,60 @@
+import { test } from '@japa/runner'
+import sinon from 'sinon'
+import env from '#start/env'
+import OpenAIService from '#services/openai_service'
+
+test.group('OpenAIService configuration', () => {
+  test('configured flag is false when OPENAI_API_KEY is missing', ({ assert }) => {
+    const getStub = env.get as unknown as sinon.SinonStub
+    getStub.callsFake((key: string, defaultValue?: any) => {
+      if (key === 'OPENAI_API_KEY') {
+        return ''
+      }
+      if (key === 'NODE_ENV') {
+        return 'test'
+      }
+      return defaultValue
+    })
+
+    const service = OpenAIService.getInstance()
+    assert.isFalse(service.configured)
+
+    getStub.callsFake((key: string, defaultValue?: any) => {
+      if (key === 'OPENAI_API_KEY') {
+        return 'test-api-key'
+      }
+      if (key === 'NODE_ENV') {
+        return 'test'
+      }
+      return defaultValue
+    })
+    ;(OpenAIService as any).instance = null
+  })
+
+  test('configured flag is true when OPENAI_API_KEY is set', ({ assert }) => {
+    const getStub = env.get as unknown as sinon.SinonStub
+    getStub.callsFake((key: string, defaultValue?: any) => {
+      if (key === 'OPENAI_API_KEY') {
+        return 'test-key'
+      }
+      if (key === 'NODE_ENV') {
+        return 'test'
+      }
+      return defaultValue
+    })
+
+    const service = OpenAIService.getInstance()
+    assert.isTrue(service.configured)
+
+    getStub.callsFake((key: string, defaultValue?: any) => {
+      if (key === 'OPENAI_API_KEY') {
+        return 'test-api-key'
+      }
+      if (key === 'NODE_ENV') {
+        return 'test'
+      }
+      return defaultValue
+    })
+    ;(OpenAIService as any).instance = null
+  })
+})

--- a/tests/unit/openai_service_config.spec.ts
+++ b/tests/unit/openai_service_config.spec.ts
@@ -4,14 +4,14 @@ import env from '#start/env'
 import OpenAIService from '#services/openai_service'
 
 test.group('OpenAIService configuration', (group) => {
-  const getStub = env.get as unknown as sinon.SinonStub
+  let getStub: sinon.SinonStub
+
+  group.each.setup(() => {
+    getStub = sinon.stub(env, 'get')
+  })
 
   group.each.teardown(() => {
-    getStub.callsFake((key: string, defaultValue?: any) => {
-      if (key === 'OPENAI_API_KEY') return 'test-api-key'
-      if (key === 'NODE_ENV') return 'test'
-      return defaultValue
-    })
+    getStub.restore()
     ;(OpenAIService as any).instance = null
   })
 
@@ -38,6 +38,12 @@ test.group('OpenAIService configuration', (group) => {
   })
 
   test('getInstance returns the same instance', ({ assert }) => {
+    getStub.callsFake((key: string, defaultValue?: any) => {
+      if (key === 'OPENAI_API_KEY') return 'test-key'
+      if (key === 'NODE_ENV') return 'test'
+      return defaultValue
+    })
+
     const first = OpenAIService.getInstance()
     const second = OpenAIService.getInstance()
     assert.strictEqual(first, second)

--- a/tests/unit/openai_service_config.spec.ts
+++ b/tests/unit/openai_service_config.spec.ts
@@ -3,58 +3,43 @@ import sinon from 'sinon'
 import env from '#start/env'
 import OpenAIService from '#services/openai_service'
 
-test.group('OpenAIService configuration', () => {
-  test('configured flag is false when OPENAI_API_KEY is missing', ({ assert }) => {
-    const getStub = env.get as unknown as sinon.SinonStub
-    getStub.callsFake((key: string, defaultValue?: any) => {
-      if (key === 'OPENAI_API_KEY') {
-        return ''
-      }
-      if (key === 'NODE_ENV') {
-        return 'test'
-      }
-      return defaultValue
-    })
+test.group('OpenAIService configuration', (group) => {
+  const getStub = env.get as unknown as sinon.SinonStub
 
-    const service = OpenAIService.getInstance()
-    assert.isFalse(service.configured)
-
+  group.each.teardown(() => {
     getStub.callsFake((key: string, defaultValue?: any) => {
-      if (key === 'OPENAI_API_KEY') {
-        return 'test-api-key'
-      }
-      if (key === 'NODE_ENV') {
-        return 'test'
-      }
+      if (key === 'OPENAI_API_KEY') return 'test-api-key'
+      if (key === 'NODE_ENV') return 'test'
       return defaultValue
     })
     ;(OpenAIService as any).instance = null
   })
 
-  test('configured flag is true when OPENAI_API_KEY is set', ({ assert }) => {
-    const getStub = env.get as unknown as sinon.SinonStub
+  test('configured flag is false when OPENAI_API_KEY is missing', ({ assert }) => {
     getStub.callsFake((key: string, defaultValue?: any) => {
-      if (key === 'OPENAI_API_KEY') {
-        return 'test-key'
-      }
-      if (key === 'NODE_ENV') {
-        return 'test'
-      }
+      if (key === 'OPENAI_API_KEY') return ''
+      if (key === 'NODE_ENV') return 'test'
+      return defaultValue
+    })
+
+    const service = OpenAIService.getInstance()
+    assert.isFalse(service.configured)
+  })
+
+  test('configured flag is true when OPENAI_API_KEY is set', ({ assert }) => {
+    getStub.callsFake((key: string, defaultValue?: any) => {
+      if (key === 'OPENAI_API_KEY') return 'test-key'
+      if (key === 'NODE_ENV') return 'test'
       return defaultValue
     })
 
     const service = OpenAIService.getInstance()
     assert.isTrue(service.configured)
+  })
 
-    getStub.callsFake((key: string, defaultValue?: any) => {
-      if (key === 'OPENAI_API_KEY') {
-        return 'test-api-key'
-      }
-      if (key === 'NODE_ENV') {
-        return 'test'
-      }
-      return defaultValue
-    })
-    ;(OpenAIService as any).instance = null
+  test('getInstance returns the same instance', ({ assert }) => {
+    const first = OpenAIService.getInstance()
+    const second = OpenAIService.getInstance()
+    assert.strictEqual(first, second)
   })
 })


### PR DESCRIPTION
## Summary
- make OpenAI service a singleton with a `configured` flag instead of throwing on missing API key
- share the OpenAI service in HomeController and guard when not configured
- add unit tests covering configuration for missing and present API key

## Testing
- `npm run lint`
- `npm run tsc` (fails: Missing script: "tsc")
- `npm run typecheck`
- `NODE_ENV=test PORT=3333 HOST=localhost APP_KEY=0123456789abcdef LOG_LEVEL=info SESSION_DRIVER=cookie DRIVE_DISK=fs DB_CONNECTION=postgres LIMITER_STORE=memory npm test`

------
https://chatgpt.com/codex/tasks/task_e_68977913ebf483279f763001ad0cfeb8